### PR TITLE
Fix error 500 when passing invalid JSON structure

### DIFF
--- a/api_v1/api_handler/queries.py
+++ b/api_v1/api_handler/queries.py
@@ -8,6 +8,7 @@ import re
 from hashlib import blake2b
 from typing import Tuple, Union, Awaitable
 from json import loads
+from json.decoder import JSONDecodeError
 from urllib.parse import unquote_plus, unquote
 
 # 3rd party:
@@ -24,7 +25,7 @@ from .constants import (
 from .exceptions import (
     IncorrectQueryValueType, InvalidQueryParameter,
     ExceedsMaxParameters, InvalidQuery, ValueNotAcceptable,
-    RequestTooLarge, UnauthorisedRequest
+    RequestTooLarge, UnauthorisedRequest, InvalidStructure
 )
 
 from .types import QueryArguments, StringOrNumber, QueryData
@@ -213,7 +214,10 @@ class QueryParser:
         if found:
             raw_json = found.group(2)
             self._query = self._query.replace(found.group(1), str())
-            structure = loads(unquote_plus(raw_json))
+            try:
+                structure = loads(unquote_plus(raw_json))
+            except JSONDecodeError:
+                raise InvalidStructure()
 
         return await format_structure(structure)
 


### PR DESCRIPTION
Currently when passing an invalid JSON object for the `structure` parameter (e.g. https://api.coronavirus.data.gov.uk/v1/data?filters=areaType=overview&structure={%22}), the error one gets is 500. This PR changes it to a 417.